### PR TITLE
Enable running package tests for the PNP exercise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test-maze:
 run-maze:
 	@docker run go-ood
 test-pnp:
-	docker run go-ood go test github.com/ronnas/go-ood/cmd/pnp
+	docker run go-ood go test github.com/ronnas/go-ood/pkg/pnp
 run-pnp:
 	@docker run -it go-ood pnp
 test-heap:

--- a/pkg/pnp/skill.go
+++ b/pkg/pnp/skill.go
@@ -2,7 +2,7 @@ package pnp
 
 //go:generate stringer -type=Skill
 
-// Skill represents a Player's skill in a Prorgammers & Platforms game
+// Skill represents a Player's skill in a Programmers & Platforms game
 type Skill int
 
 // Skills

--- a/pkg/pnp/state_test.go
+++ b/pkg/pnp/state_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestReactSuccessful(t *testing.T) {
-	t.Parallel()
 	tt := []struct {
 		State      State
 		Health, XP int
@@ -47,7 +46,6 @@ func TestReactSuccessful(t *testing.T) {
 
 }
 func TestReactUnsuccessful(t *testing.T) {
-	t.Parallel()
 	tt := []struct {
 		State      State
 		Health, XP int


### PR DESCRIPTION
Disables parallel tests where running tests in parallel is unsafe, plus a bonus typo fix.